### PR TITLE
Changed deprecated reference to scikit-learn in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
         'scipy',
         'tqdm',
         'h5py',
-        'sklearn',
+        'scikit-learn',
         'tqdm',
         'sphinx_rtd_theme'
         ]


### PR DESCRIPTION
sklearn is now deprecated and peripy installation was failing. Changed name to scikit-learn in install_requires, which solved the issue